### PR TITLE
fix server.py path for colab in OmniParse_GoogleColab.ipynb

### DIFF
--- a/examples/OmniParse_GoogleColab.ipynb
+++ b/examples/OmniParse_GoogleColab.ipynb
@@ -183,7 +183,7 @@
         "\n",
         "threading.Thread(target=iframe_thread, daemon=True, args=(8000,)).start()\n",
         "\n",
-        "!python server.py --host 127.0.0.1 --port 8000 --documents --media --web"
+        "!python omniparse/server.py --host 127.0.0.1 --port 8000 --documents --media --web"
       ]
     },
     {


### PR DESCRIPTION
Fixed the path to server.py in the colab demo

<img width="736" alt="Screenshot 2024-06-28 at 11 04 01 AM" src="https://github.com/samarth777/omniparse/assets/63744278/59c530f6-a966-4530-9d2f-03175546ab11">
